### PR TITLE
Update sessionExpiryTimerStarted when snapshot refreshes

### DIFF
--- a/packages/common/container-definitions/api-report/container-definitions.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.api.md
@@ -365,6 +365,7 @@ export { IGenericError }
 // @alpha
 export interface IGetPendingLocalStateProps {
     readonly notifyImminentClosure: boolean;
+    readonly sessionExpiryTimerStarted?: number;
     readonly stopBlobAttachingSignal?: AbortSignal;
 }
 

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -260,4 +260,10 @@ export interface IGetPendingLocalStateProps {
 	 * be preserved and collected.
 	 */
 	readonly stopBlobAttachingSignal?: AbortSignal;
+
+	/**
+	 * Date to be used as the starting time of a session. This date is updated in case we refresh the
+	 * base snapshot since we won't be referencing ops older than the new snapshot.
+	 */
+	readonly sessionExpiryTimerStarted?: number;
 }

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -185,6 +185,15 @@ export class SerializedStateManager {
 			);
 			this.snapshot = this.latestSnapshot;
 			this.latestSnapshot = undefined;
+			this.mc.logger.sendTelemetryEvent({
+				eventName: "SnapshotRefreshed",
+				snapshotSequenceNumber,
+				firstProcessedOpSequenceNumber,
+				newFirstProcessedOpSequenceNumber:
+					this.processedOps.length === 0
+						? undefined
+						: this.processedOps[0].sequenceNumber,
+			});
 		}
 	}
 

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -185,7 +185,8 @@ export class SerializedStateManager {
 				snapshotSequenceNumber - firstProcessedOpSequenceNumber + 1,
 			);
 			this.snapshot = this.latestSnapshot;
-			this.sessionExpiryTimerStarted = Date.now();
+			this.sessionExpiryTimerStarted =
+				this.processedOps.length === 0 ? Date.now() : this.processedOps[0].timestamp;
 			this.latestSnapshot = undefined;
 			this.mc.logger.sendTelemetryEvent({
 				eventName: "SnapshotRefreshed",

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -4300,7 +4300,9 @@ export class ContainerRuntime
 				pending,
 				pendingIdCompressorState,
 				pendingAttachmentBlobs,
-				sessionExpiryTimerStarted: this.garbageCollector.sessionExpiryTimerStarted,
+				sessionExpiryTimerStarted:
+					props?.sessionExpiryTimerStarted ??
+					this.garbageCollector.sessionExpiryTimerStarted,
 			};
 		};
 		const perfEvent = {

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -643,6 +643,18 @@ use_old_InterfaceDeclaration_IGarbageCollectionDetailsBase(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedInterfaceDeclaration_IIdCompressor": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedInterfaceDeclaration_IIdCompressor": {"backCompat": false}
+*/
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IInboundSignalMessage": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IInboundSignalMessage():
@@ -1071,6 +1083,54 @@ declare function use_old_InterfaceDeclaration_OpAttributionKey(
     use: TypeOnly<old.OpAttributionKey>): void;
 use_old_InterfaceDeclaration_OpAttributionKey(
     get_current_InterfaceDeclaration_OpAttributionKey());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedTypeAliasDeclaration_OpSpaceCompressedId": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedTypeAliasDeclaration_OpSpaceCompressedId": {"backCompat": false}
+*/
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedTypeAliasDeclaration_SessionId": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedTypeAliasDeclaration_SessionId": {"backCompat": false}
+*/
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedTypeAliasDeclaration_SessionSpaceCompressedId": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedTypeAliasDeclaration_SessionSpaceCompressedId": {"backCompat": false}
+*/
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedTypeAliasDeclaration_StableId": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedTypeAliasDeclaration_StableId": {"backCompat": false}
+*/
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/test/test-end-to-end-tests/src/test/refreshSerializedStateManager.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/refreshSerializedStateManager.spec.ts
@@ -1,0 +1,203 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import assert from "assert";
+import {
+	ChannelFactoryRegistry,
+	ITestFluidObject,
+	DataObjectFactoryType,
+	createAndAttachContainer,
+	createDocumentId,
+	waitForContainerConnection,
+} from "@fluidframework/test-utils";
+import { describeCompat } from "@fluid-private/test-version-utils";
+import { IContainerExperimental } from "@fluidframework/container-loader/internal";
+import {
+	ConfigTypes,
+	IConfigProviderBase,
+	type ITelemetryBaseLogger,
+} from "@fluidframework/core-interfaces";
+import {
+	DefaultSummaryConfiguration,
+	type IContainerRuntimeOptions,
+} from "@fluidframework/container-runtime";
+import { MockLogger } from "@fluidframework/telemetry-utils";
+import { Deferred } from "@fluidframework/core-utils";
+import type { ISharedMap } from "@fluidframework/map";
+import { wrapObjectAndOverride } from "../mocking.js";
+
+const mapId = "map";
+const testKey = "test key";
+const testValue = "test value";
+const mockLogger = new MockLogger();
+
+describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider, apis) => {
+	const { SharedMap } = apis.dds;
+	const registry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];
+	const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
+		getRawConfig: (name: string): ConfigTypes => settings[name],
+	});
+	const runtimeOptions: IContainerRuntimeOptions = {
+		summaryOptions: {
+			summaryConfigOverrides: {
+				...DefaultSummaryConfiguration,
+				...{
+					maxTime: 5000 * 12,
+					maxAckWaitTime: 120000,
+					maxOps: 1,
+					initialSummarizerDelayMs: 20,
+				},
+			},
+		},
+		enableRuntimeIdCompressor: "on",
+	};
+
+	const waitForSummary = async (container) => {
+		await new Promise<void>((resolve, reject) => {
+			let summarized = false;
+			container.on("op", (op) => {
+				if (op.type === "summarize") {
+					summarized = true;
+				} else if (summarized && op.type === "summaryAck") {
+					resolve();
+				} else if (op.type === "summaryNack") {
+					reject(new Error("summaryNack"));
+				}
+			});
+		});
+	};
+
+	it("snapshot was refreshed", async () => {
+		const provider = getTestObjectProvider();
+		const deferred = new Deferred<void>();
+		const testContainerConfig = {
+			fluidDataObjectType: DataObjectFactoryType.Test,
+			registry,
+			runtimeOptions,
+			loaderProps: {
+				logger: wrapObjectAndOverride<ITelemetryBaseLogger>(mockLogger, {
+					send: (tb) => (event) => {
+						tb.send(event);
+						if (
+							event.eventName ===
+							"fluid:telemetry:serializedStateManager:SnapshotRefreshed"
+						) {
+							assert(
+								event.snapshotSequenceNumber ?? 0 > 0,
+								"snapshot was not refreshed",
+							);
+							assert.strictEqual(
+								event.firstProcessedOpSequenceNumber ?? 0,
+								1,
+								"first sequenced op was not saved",
+							);
+							assert(
+								event.newFirstProcessedOpSequenceNumber ?? 0 > 1,
+								"processed ops were not refreshed",
+							);
+							deferred.resolve();
+						}
+					},
+				}),
+				configProvider: configProvider({
+					"Fluid.Container.enableOfflineLoad": true,
+				}),
+			},
+		};
+		const loader = provider.makeTestLoader(testContainerConfig);
+		const container: IContainerExperimental = await createAndAttachContainer(
+			provider.defaultCodeDetails,
+			loader,
+			provider.driver.createCreateNewRequest(createDocumentId()),
+		);
+
+		const url = await container.getAbsoluteUrl("");
+		assert(url, "no url");
+
+		const dataStore = (await container.getEntryPoint()) as ITestFluidObject;
+		const map = await dataStore.getSharedObject<ISharedMap>(mapId);
+		map.set(testKey, testValue);
+		await waitForSummary(container);
+		const pendingOps = await container.closeAndGetPendingLocalState?.();
+		assert.ok(pendingOps);
+		// make sure we got stashed ops with seqnum === 0,
+		assert(/sequenceNumber[^\w,}]*0/.test(pendingOps));
+
+		const container1: IContainerExperimental = await loader.resolve({ url }, pendingOps);
+		await deferred.promise;
+		const pendingOps2 = await container1.closeAndGetPendingLocalState?.();
+		const container2: IContainerExperimental = await loader.resolve({ url }, pendingOps2);
+		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
+		const map2 = await dataStore2.getSharedObject<ISharedMap>(mapId);
+		await waitForContainerConnection(container2, true);
+		await provider.ensureSynchronized();
+		assert.strictEqual(map2.get(testKey), testValue);
+	});
+
+	it("snapshot was not refreshed", async () => {
+		const provider = getTestObjectProvider();
+		const deferred = new Deferred<void>();
+		const testContainerConfig = {
+			fluidDataObjectType: DataObjectFactoryType.Test,
+			registry,
+			runtimeOptions,
+			loaderProps: {
+				logger: wrapObjectAndOverride<ITelemetryBaseLogger>(mockLogger, {
+					send: (tb) => (event) => {
+						tb.send(event);
+						if (
+							event.eventName ===
+							"fluid:telemetry:serializedStateManager:OldSnapshotFetchWhileRefreshing"
+						) {
+							assert.strictEqual(event.category, "generic", "wrong event category");
+							assert.strictEqual(
+								event.snapshotSequenceNumber ?? -1,
+								0,
+								"snapshot was refreshed when it shouldn't",
+							);
+							assert.strictEqual(
+								event.firstProcessedOpSequenceNumber ?? 0,
+								1,
+								"first sequenced op was not saved",
+							);
+							deferred.resolve();
+						}
+					},
+				}),
+				configProvider: configProvider({
+					"Fluid.Container.enableOfflineLoad": true,
+				}),
+			},
+		};
+		const loader = provider.makeTestLoader(testContainerConfig);
+		const container: IContainerExperimental = await createAndAttachContainer(
+			provider.defaultCodeDetails,
+			loader,
+			provider.driver.createCreateNewRequest(createDocumentId()),
+		);
+
+		const url = await container.getAbsoluteUrl("");
+		assert(url, "no url");
+
+		const dataStore = (await container.getEntryPoint()) as ITestFluidObject;
+		const map = await dataStore.getSharedObject<ISharedMap>(mapId);
+		map.set(testKey, testValue);
+		// not waiting for summary to reuse the stashed snapshot for new loaded containers
+		const pendingOps = await container.closeAndGetPendingLocalState?.();
+		assert.ok(pendingOps);
+		// make sure we got stashed ops with seqnum === 0,
+		assert(/sequenceNumber[^\w,}]*0/.test(pendingOps));
+
+		const container1: IContainerExperimental = await loader.resolve({ url }, pendingOps);
+		await deferred.promise;
+		const pendingOps2 = await container1.closeAndGetPendingLocalState?.();
+		const container2: IContainerExperimental = await loader.resolve({ url }, pendingOps2);
+		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
+		const map2 = await dataStore2.getSharedObject<ISharedMap>(mapId);
+		await waitForContainerConnection(container2, true);
+		await provider.ensureSynchronized();
+		assert.strictEqual(map2.get(testKey), testValue);
+	});
+});

--- a/packages/test/test-end-to-end-tests/src/test/refreshSerializedStateManager.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/refreshSerializedStateManager.spec.ts
@@ -71,7 +71,7 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 
 	it("snapshot was refreshed", async () => {
 		const provider = getTestObjectProvider();
-		const deferred = new Deferred<void>();
+		const getLatestSnapshotInfoP = new Deferred<void>();
 		const testContainerConfig = {
 			fluidDataObjectType: DataObjectFactoryType.Test,
 			registry,
@@ -97,7 +97,7 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 								event.newFirstProcessedOpSequenceNumber ?? 0 > 1,
 								"processed ops were not refreshed",
 							);
-							deferred.resolve();
+							getLatestSnapshotInfoP.resolve();
 						}
 					},
 				}),
@@ -126,7 +126,7 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 		assert(/sequenceNumber[^\w,}]*0/.test(pendingOps));
 
 		const container1: IContainerExperimental = await loader.resolve({ url }, pendingOps);
-		await deferred.promise;
+		await getLatestSnapshotInfoP.promise;
 		const pendingOps2 = await container1.closeAndGetPendingLocalState?.();
 		const container2: IContainerExperimental = await loader.resolve({ url }, pendingOps2);
 		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
@@ -138,7 +138,7 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 
 	it("snapshot was not refreshed", async () => {
 		const provider = getTestObjectProvider();
-		const deferred = new Deferred<void>();
+		const getLatestSnapshotInfoP = new Deferred<void>();
 		const testContainerConfig = {
 			fluidDataObjectType: DataObjectFactoryType.Test,
 			registry,
@@ -162,7 +162,7 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 								1,
 								"first sequenced op was not saved",
 							);
-							deferred.resolve();
+							getLatestSnapshotInfoP.resolve();
 						}
 					},
 				}),
@@ -191,7 +191,7 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 		assert(/sequenceNumber[^\w,}]*0/.test(pendingOps));
 
 		const container1: IContainerExperimental = await loader.resolve({ url }, pendingOps);
-		await deferred.promise;
+		await getLatestSnapshotInfoP.promise;
 		const pendingOps2 = await container1.closeAndGetPendingLocalState?.();
 		const container2: IContainerExperimental = await loader.resolve({ url }, pendingOps2);
 		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;


### PR DESCRIPTION
When the snapshot refreshes at loading when using a pending local state, we need to move the session expiry timer forward to avoid closing the container sooner than we could. The new time should be the moment in which the new first processed op was sequenced